### PR TITLE
Downgrade csv-parser

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -65,7 +65,13 @@ prog
   .help('builds config file for a site')
   .argument('site', 'The site to build from')
   .action((args) => {
-    Build.configExport(args.site, config);
+    Build.configExport(args.site, config, (err) => {
+      if (err) {
+        console.log(chalk.red(JSON.stringify(err))); // eslint-disable-line no-console
+      } else {
+        console.log(chalk.green('Config exported.')); // eslint-disable-line no-console
+      }
+    });
   })
   .command('build-datajson')
   .help('builds data.json file for a site')
@@ -171,7 +177,7 @@ prog
     process.env.NODE_ENV = 'production';
     process.env.SITE = args.site;
     process.env.PATH += (path.delimiter + path.join(__dirname, 'node_modules', '.bin'));
-    shell.exec('webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules');
+    shell.exec('node_modules/.bin/webpack --config internals/webpack/webpack.prod.babel.js --color -p --progress --hide-modules');
   })
   .command('run-dev')
   .help('runs dev server for a site.')

--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "cheerio": "^0.22.0",
     "compression": "1.6.2",
     "cross-env": "5.0.0",
-    "csv-parse": "^2.0.0",
+    "csv-parse": "1.2.2",
     "elasticlunr": "^0.9.5",
     "elasticsearch": "^14.0.0",
     "ellipsize": "0.0.3",


### PR DESCRIPTION
This address #22. Downgrades csv-parser so template literals aren't passed to uglify causing an error.